### PR TITLE
A potential fix for sagan progressHandler

### DIFF
--- a/src/sagan/ChangefeedProcessor.fs
+++ b/src/sagan/ChangefeedProcessor.fs
@@ -186,8 +186,9 @@ let go (cosmos:CosmosEndpoint) (config:Config) handle progressHandler = async {
     let index = cfp |> Array.tryFindIndex (function x -> x.RangeMin=rp.RangeMin && x.RangeMax=rp.RangeMax)
     match index with
     | Some i ->
-      cfp.[i] <- rp
-      Array.copy cfp
+      let newCfp = Array.copy cfp
+      newCfp.[i] <- rp
+      newCfp
     | None ->
       let newCfp = Array.zeroCreate (cfp.Length+1)
       for i in 0..cfp.Length-1 do

--- a/src/sagan/ChangefeedProcessor.fs
+++ b/src/sagan/ChangefeedProcessor.fs
@@ -187,7 +187,7 @@ let go (cosmos:CosmosEndpoint) (config:Config) handle progressHandler = async {
     match index with
     | Some i ->
       cfp.[i] <- rp
-      cfp
+      Array.copy cfp
     | None ->
       let newCfp = Array.zeroCreate (cfp.Length+1)
       for i in 0..cfp.Length-1 do


### PR DESCRIPTION
Sagan returns a mutable array to indicate changefeedprocessor progress which can be updated unexpectedly. This fix makes progressHandler return a deep copy of array instead.