### PR TITLE
Added partition filtering to Changefeed Processor

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 0.0.10
+* Added partition filtering for changefeed processor
+
 ### 0.0.9
 * Added a retry delay for querying a partition when the changefeed processor reaches the tail of that partition.
 


### PR DESCRIPTION
Added a `PartitionSelector` to the Changefeed Processor. A `PartitionSelector: PartitionKeyRange[] -> PartitionKeyRange[]` is a function that filters down the list of partitions that the changefeed processor will process.