### PR TITLE
Fix bug for missing partition

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 0.0.15-alpha
+* Added timestamp for tail tacking
+
 ### 0.0.14-alpha
 * Fixed issue for missing partitions in progress handler.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 0.0.14-alpha
+* Fixed issue for missing partitions in progress handler.
+
 ### 0.0.13-alpha
 * lower FSharp.Core version requirements
 

--- a/src/sagan/ChangefeedProcessor.fs
+++ b/src/sagan/ChangefeedProcessor.fs
@@ -266,7 +266,7 @@ let go (cosmos:CosmosEndpoint) (config:Config) (partitionSelector:PartitionSelec
 
 /// Periodically queries DocDB for the latest positions and timestamp of all partitions in its changefeed.
 /// The `handler` function will be called periodically, once per `interval`, with an updated ChangefeedPosition and timestamp of last document
-let trackTailPosition (cosmos:CosmosEndpoint) (interval:TimeSpan) (handler:DateTime*(DateTime[]*ChangefeedPosition) -> Async<unit>) = async {
+let trackTailPosition (cosmos:CosmosEndpoint) (interval:TimeSpan) (handler:DateTime*(DateTime*RangePosition)[] -> Async<unit>) = async {
   use client = new DocumentClient(cosmos.uri, cosmos.authKey)
   let state = {
     client = client
@@ -304,7 +304,6 @@ let trackTailPosition (cosmos:CosmosEndpoint) (interval:TimeSpan) (handler:DateT
       partitions
       |> Array.map getRecentPosition
       |> Async.Parallel
-      |> Async.bind (Array.unzip >> async.Return)
     return (dateTime, changefeedPosition)
   }
 


### PR DESCRIPTION
Some partitions missing from OffsetIndex sometimes.
The reason is that those partitions don't have new data in progress interval after restart of changefeed processor.
This can be fixed by set initial state using start position from config instead of an empty array.